### PR TITLE
3.0.0 - Implement bundle & virtual product functionality (patch/19627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2024-02-02
+### Added
+- Add subscription support for Bundle products that meet the following criteria:
+  - Fixed price
+  - Maximum of 1 product per option
+  - Maximum of 0 products with "user defined" enabled
+- Add subscription support for Virtual Product Type

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -382,7 +382,7 @@ class Data extends AbstractHelper
                 'quantity' => $childData->getData('selection_qty') ?? '',
                 'sku' => $childData->getSku(),
                 'name' => $childData->getName(),
-                'selection_price' => $childData->getData('selection_price_value') ?? ''
+                'selection_price' =>  $this->formatPrice((float)$childData->getData('selection_price_value'))
             ];
         }
 

--- a/Model/Config/Source/Subscription/Allmethods.php
+++ b/Model/Config/Source/Subscription/Allmethods.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PayPal\Subscription\Model\Config\Source\Subscription;
 
+use PayPal\Braintree\Model\Ui\ConfigProvider;
+
 class Allmethods extends \Magento\Payment\Model\Config\Source\Allmethods
 {
     /**
@@ -12,6 +14,7 @@ class Allmethods extends \Magento\Payment\Model\Config\Source\Allmethods
     public function toOptionArray(): array
     {
         $paymentList = $this->_paymentData->getPaymentMethodList(true, true, true);
-        return isset($paymentList['braintree_group']) ? ['braintree_group' => $paymentList['braintree_group']] : [];
+        $groupName = ConfigProvider::CODE . '_group';
+        return isset($paymentList[$groupName]) ? [$groupName => $paymentList[$groupName]] : [];
     }
 }

--- a/Model/Config/Source/Subscription/Allmethods.php
+++ b/Model/Config/Source/Subscription/Allmethods.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPal\Subscription\Model\Config\Source\Subscription;
+
+class Allmethods extends \Magento\Payment\Model\Config\Source\Allmethods
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        $paymentList = $this->_paymentData->getPaymentMethodList(true, true, true);
+        return isset($paymentList['braintree_group']) ? ['braintree_group' => $paymentList['braintree_group']] : [];
+    }
+}

--- a/Model/Config/Source/Subscription/BraintreeMethods.php
+++ b/Model/Config/Source/Subscription/BraintreeMethods.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PayPal\Subscription\Model\Config\Source\Subscription;
 
+use Magento\Payment\Model\Config\Source\Allmethods;
 use PayPal\Braintree\Model\Ui\ConfigProvider;
 
-class Allmethods extends \Magento\Payment\Model\Config\Source\Allmethods
+class BraintreeMethods extends Allmethods
 {
     /**
      * @return array

--- a/Model/GuestQuoteManagement.php
+++ b/Model/GuestQuoteManagement.php
@@ -60,6 +60,10 @@ class GuestQuoteManagement implements GuestQuoteManagementInterface
             throw new LocalizedException(__('Unable to fetch quote.'));
         }
 
-        return $this->quoteManagement->changeFrequency($quoteIdMask->getData('quote_id'), $quoteItemId, $frequency);
+        return $this->quoteManagement->changeFrequency(
+            (int) $quoteIdMask->getData('quote_id'),
+            $quoteItemId,
+            $frequency
+        );
     }
 }

--- a/Observer/DisableBundleAttributes.php
+++ b/Observer/DisableBundleAttributes.php
@@ -29,7 +29,7 @@ class DisableBundleAttributes implements ObserverInterface
         if ((bool)$product->getData(Data::SUB_AVAILABLE) === true && !$this->bundleEligibleForSubscription($product)) {
             throw new CouldNotSaveException(__(
                 "Bundle configuration is not eligible for subscriptions.
-                 Please ensure bundle is fixed price and contains no 'User Defined' options."
+                 Please ensure bundle is fixed price, has one product per option and contains no user defined options."
             ));
         }
     }
@@ -44,7 +44,8 @@ class DisableBundleAttributes implements ObserverInterface
     }
 
     /**
-     * Return false if bundle is dynamically priced OR contains ANY options that are user defined.
+     * Return false IF bundle is dynamically priced OR bundle has more than one selection per option OR
+     * bundle contains ANY selections that are user defined === true.
      *
      * @param ProductInterface $product
      * @return bool
@@ -56,6 +57,9 @@ class DisableBundleAttributes implements ObserverInterface
         }
 
         foreach ($product->getData('bundle_selections_data') as $optionData) {
+            if (count($optionData) > 1) {
+                return false;
+            }
             foreach ($optionData as $selection) {
                 if ((bool)$selection['selection_can_change_qty'] === true) {
                     return false;

--- a/Observer/DisableBundleAttributes.php
+++ b/Observer/DisableBundleAttributes.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPal\Subscription\Observer;
+
+use Magento\Bundle\Model\Product\Price;
+use Magento\Bundle\Model\Product\Type;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\CouldNotSaveException;
+use PayPal\Subscription\Helper\Data;
+
+class DisableBundleAttributes implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     * @throws CouldNotSaveException
+     */
+    public function execute(Observer $observer): void
+    {
+        $product = $observer->getData('product');
+        if (!$this->isProductBundle($product)) {
+            return;
+        }
+
+        if ((bool)$product->getData(Data::SUB_AVAILABLE) === true && !$this->bundleEligibleForSubscription($product)) {
+            throw new CouldNotSaveException(__(
+                "Bundle configuration is not eligible for subscriptions.
+                 Please ensure bundle is fixed price and contains no 'User Defined' options."
+            ));
+        }
+    }
+
+    /**
+     * @param ProductInterface|null $product
+     * @return bool
+     */
+    private function isProductBundle(?ProductInterface $product): bool
+    {
+        return $product instanceof ProductInterface && $product->getTypeId() === Type::TYPE_CODE;
+    }
+
+    /**
+     * Return false if bundle is dynamically priced OR contains ANY options that are user defined.
+     *
+     * @param ProductInterface $product
+     * @return bool
+     */
+    private function bundleEligibleForSubscription(ProductInterface $product): bool
+    {
+        if ((int)$product->getPriceType() === Price::PRICE_TYPE_DYNAMIC) {
+            return false;
+        }
+
+        foreach ($product->getData('bundle_selections_data') as $optionData) {
+            foreach ($optionData as $selection) {
+                if ((bool)$selection['selection_can_change_qty'] === true) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/Observer/DisableBundleAttributes.php
+++ b/Observer/DisableBundleAttributes.php
@@ -11,9 +11,17 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 use PayPal\Subscription\Helper\Data;
+use PayPal\Subscription\Model\ConfigurationInterface;
 
 class DisableBundleAttributes implements ObserverInterface
 {
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(private readonly ConfigurationInterface $configuration)
+    {
+    }
+
     /**
      * @param Observer $observer
      * @return void
@@ -22,7 +30,7 @@ class DisableBundleAttributes implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $product = $observer->getData('product');
-        if (!$this->isProductBundle($product)) {
+        if ($this->configuration->getActive() === false || !$this->isProductBundle($product)) {
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PayPal Subscription 2.0.0
+# PayPal Subscription 3.0.0
 
 Once a Braintree account has been created and the supporting Payments module installed, merchants can enable the subscription functionality on any of their products in Magento. Orders will be created within Magento on an automated basis with payments being processed though the Braintree PayPal or Card payment methods.
 

--- a/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
+++ b/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace PayPal\Subscription\Setup\Patch\Data;
+
+use Magento\Catalog\Model\Product;
+use Magento\Eav\Setup\EavSetup;
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Class UpdateProductSubscriptionAttributes
+ *
+ * Update custom subscription attributes to products
+ */
+class ApplyBundleTypeToSubscriptionAttributes implements DataPatchInterface
+{
+    public const SUBSCRIPTION_AVAILABLE = 'subscription_available';
+    public const SUBSCRIPTION_ONLY = 'subscription_only';
+    public const SUBSCRIPTION_PRICE_TYPE = 'subscription_price_type';
+    public const SUBSCRIPTION_PRICE_VALUE = 'subscription_price_value';
+    public const SUBSCRIPTION_FREQUENCY_PROFILE = 'subscription_frequency_profile';
+    public const RECOMMENDED_FREQUENCY_ATTRIBUTE_CODE = 'recommended_frequency';
+
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private ModuleDataSetupInterface $moduleDataSetup;
+
+    /**
+     * @var EavSetupFactory
+     */
+    private EavSetupFactory $eavSetupFactory;
+
+    /**
+     * @var EavSetup
+     */
+    private EavSetup $eavSetup;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param EavSetupFactory $eavSetupFactory
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        EavSetupFactory $eavSetupFactory
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getDependencies(): array
+    {
+        return [
+            AddProductSubscriptionAttributes::class,
+            InstallRecommendedFrequencyAttributes::class
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return void
+     */
+    public function apply(): void
+    {
+        $this->eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
+        $attributes = [
+            self::SUBSCRIPTION_AVAILABLE,
+            self::SUBSCRIPTION_ONLY,
+            self::SUBSCRIPTION_PRICE_TYPE,
+            self::SUBSCRIPTION_PRICE_VALUE,
+            self::SUBSCRIPTION_FREQUENCY_PROFILE,
+            self::RECOMMENDED_FREQUENCY_ATTRIBUTE_CODE
+        ];
+        foreach ($attributes as $attribute) {
+            $this->eavSetup->updateAttribute(
+                Product::ENTITY,
+                $attribute,
+                'apply_to',
+                'simple,configurable,downloadable,bundle'
+            );
+        }
+    }
+}

--- a/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
+++ b/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
@@ -89,7 +89,7 @@ class ApplyBundleTypeToSubscriptionAttributes implements DataPatchInterface
                 Product::ENTITY,
                 $attribute,
                 'apply_to',
-                'simple,configurable,downloadable,bundle'
+                'simple,configurable,downloadable,bundle,virtual'
             );
         }
     }

--- a/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
+++ b/Setup/Patch/Data/ApplyBundleTypeToSubscriptionAttributes.php
@@ -57,7 +57,8 @@ class ApplyBundleTypeToSubscriptionAttributes implements DataPatchInterface
     {
         return [
             AddProductSubscriptionAttributes::class,
-            InstallRecommendedFrequencyAttributes::class
+            InstallRecommendedFrequencyAttributes::class,
+            UpdateProductSubscriptionAttributes::class
         ];
     }
 

--- a/ViewModel/Customer/SubscriptionList.php
+++ b/ViewModel/Customer/SubscriptionList.php
@@ -573,6 +573,7 @@ class SubscriptionList implements ArgumentInterface
             return $optionData;
         }
 
+        /** @var \Magento\Bundle\Model\Product\Type $typeInstance */
         $typeInstance = $subscriptionProduct->getTypeInstance();
         $optionMap = $typeInstance->getOptions($subscriptionProduct);
         $bundleSelections = $typeInstance->getSelectionsCollection(

--- a/ViewModel/Email.php
+++ b/ViewModel/Email.php
@@ -156,7 +156,11 @@ class Email implements ArgumentInterface
             return '';
         }
 
-        $price = $this->formatPrice((float)$selectionData['selection_price']);
-        return sprintf('%d x %s %s', (int)$selectionData['quantity'], $selectionData['name'], $price);
+        return sprintf(
+            '%d x %s %s',
+            (int)$selectionData['quantity'],
+            $selectionData['name'],
+            $selectionData['selection_price']
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Enable products to be purchased as a subscription.",
     "type": "magento2-module",
     "license": "proprietary",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "authors": [
         {
             "email": "hello@gene.co.uk",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -47,7 +47,7 @@
                 </field>
                 <field id="allowed_payment_methods" translate="label comment" type="multiselect" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Allowed Payment Methods</label>
-                    <source_model>PayPal\Subscription\Model\Config\Source\Subscription\Allmethods</source_model>
+                    <source_model>PayPal\Subscription\Model\Config\Source\Subscription\BraintreeMethods</source_model>
                     <comment>Defines available payment methods for order with subscription product, all other payment methods will be disabled.</comment>
                     <config_path>paypal/subscriptions/allowed_payment_methods</config_path>
                     <depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -47,7 +47,7 @@
                 </field>
                 <field id="allowed_payment_methods" translate="label comment" type="multiselect" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Allowed Payment Methods</label>
-                    <source_model>Magento\Payment\Model\Config\Source\Allmethods</source_model>
+                    <source_model>PayPal\Subscription\Model\Config\Source\Subscription\Allmethods</source_model>
                     <comment>Defines available payment methods for order with subscription product, all other payment methods will be disabled.</comment>
                     <config_path>paypal/subscriptions/allowed_payment_methods</config_path>
                     <depends>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -31,4 +31,7 @@
     <event name="payment_method_is_active">
         <observer name="paypal_subscription_active_payments" instance="PayPal\Subscription\Observer\PaymentActiveObserver" />
     </event>
+    <event name="catalog_product_save_before">
+        <observer name="paypal_subscription_disable_bundle_attributes" instance="PayPal\Subscription\Observer\DisableBundleAttributes" />
+    </event>
 </config>

--- a/view/frontend/templates/email/subscription_items.phtml
+++ b/view/frontend/templates/email/subscription_items.phtml
@@ -24,16 +24,43 @@ $viewModel = $block->getViewModel();
         </thead>
         <?php foreach ($items as $_item) : ?>
             <tbody>
-            <tr>
-                <td class="item-info">
-                    <p class="product-name"><?= $block->escapeHtml($viewModel->getProductName($_item)) ?></p>
-                    <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($_item->getSku()) ?></p>
-                </td>
-                <td class="item-qty"><?= (float) $_item->getQty() ?></td>
-                <td class="item-price">
-                    <?= /* @noEscape */ $viewModel->formatPrice($_item->getPrice()); ?>
-                </td>
-            </tr>
+            <?php if (!$bundleData = $viewModel->getBundleData($_item)) : ?>
+                <tr>
+                    <td class="item-info">
+                        <p class="product-name"><?= $block->escapeHtml($viewModel->getProductName($_item)) ?></p>
+                        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($_item->getSku()) ?></p>
+                    </td>
+                    <td class="item-qty"><?= (float) $_item->getQty() ?></td>
+                    <td class="item-price">
+                        <?= /* @noEscape */ $viewModel->formatPrice($_item->getPrice()); ?>
+                    </td>
+                </tr>
+            <?php else : ?>
+                <tr class="bundle-item bundle-parent">
+                    <td class="item-info">
+                        <p class="product-name"><?= $block->escapeHtml($viewModel->getProductName($_item)) ?></p>
+                        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($_item->getSku()) ?></p>
+                    </td>
+                    <td class="item-qty"><?= (float) $_item->getQty() ?></td>
+                    <td class="item-price">
+                        <?= /* @noEscape */ $viewModel->formatPrice($_item->getPrice()); ?>
+                    </td>
+                </tr>
+                <?php foreach ($bundleData as $optionTitle => $selectionData) : ?>
+                    <tr class="bundle-option-label">
+                        <td colspan="3">
+                            <strong><em><?= $block->escapeHtml($optionTitle) ?></em></strong>
+                        </td>
+                    </tr>
+                    <?php foreach ($selectionData as $selection) : ?>
+                        <tr class="bundle-item bundle-option-value">
+                            <td class="item-info" colspan="3">
+                                <p><?= $block->escapeHtml($viewModel->getSelectionString($selection)) ?></p>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endforeach; ?>
+            <?php endif; ?>
             </tbody>
         <?php endforeach; ?>
     </table>

--- a/view/frontend/web/css/source/account/_subscription.less
+++ b/view/frontend/web/css/source/account/_subscription.less
@@ -36,6 +36,22 @@
 
             .product {
                 text-align: center;
+
+                &-info {
+                    &__options {
+                        &-list {
+                            text-align: center;
+                            background-color: @color-gray-light0;
+                            padding: @indent__s 0;
+                            margin: @indent__s 0 @indent__xs;
+                        }
+
+                        &-title {
+                            font-weight: @font-weight__bold;
+                            margin-bottom: @indent__s;
+                        }
+                    }
+                }
             }
 
             .qty__wrapper {

--- a/view/frontend/web/js/action/address/add-billing-address.js
+++ b/view/frontend/web/js/action/address/add-billing-address.js
@@ -25,7 +25,7 @@ define([
 
         return storage
             .put(url, JSON.stringify(address), false)
-            .success(function (response) {
+            .done(function (response) {
                 // Return Response
                 return response;
             });

--- a/view/frontend/web/js/action/address/add-shipping-address.js
+++ b/view/frontend/web/js/action/address/add-shipping-address.js
@@ -25,7 +25,7 @@ define([
 
         return storage
             .put(url, JSON.stringify(address), false)
-            .success(function (response) {
+            .done(function (response) {
                 // Return Response
                 return response;
             });

--- a/view/frontend/web/js/action/address/set-billing-address.js
+++ b/view/frontend/web/js/action/address/set-billing-address.js
@@ -26,7 +26,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/address/set-shipping-address.js
+++ b/view/frontend/web/js/action/address/set-shipping-address.js
@@ -24,7 +24,7 @@ define([
          * @param {String} message
          */
 
-        return storage.put(url, {}, false).success(function (response) {
+        return storage.put(url, {}, false).done(function (response) {
             // Return Response
             return response;
         });

--- a/view/frontend/web/js/action/customer/payment/load-client-token.js
+++ b/view/frontend/web/js/action/customer/payment/load-client-token.js
@@ -20,7 +20,7 @@ define([
 
         return storage.get(
             url
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/payment/set-existing-method.js
+++ b/view/frontend/web/js/action/customer/payment/set-existing-method.js
@@ -26,7 +26,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/payment/update-braintree-cc-payment.js
+++ b/view/frontend/web/js/action/customer/payment/update-braintree-cc-payment.js
@@ -21,7 +21,7 @@ define([
         return storage.put(
             url,
             JSON.stringify({nonce: response})
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/payment/update-braintree-paypal-payment.js
+++ b/view/frontend/web/js/action/customer/payment/update-braintree-paypal-payment.js
@@ -22,7 +22,7 @@ define([
         return storage.put(
             url,
             JSON.stringify({nonce: response})
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/view/send-order-now.js
+++ b/view/frontend/web/js/action/customer/view/send-order-now.js
@@ -1,7 +1,3 @@
-/**
- * PayPal Subscriptions
- */
-
 define([
     'jquery',
     'mage/storage',
@@ -10,7 +6,6 @@ define([
     'use strict';
 
     return function (subscriptionId, qty) {
-
         var url = urlBuilder.createUrl('/subscription/mine/sendOrderNow/:subscriptionId', {
             subscriptionId: subscriptionId
         });
@@ -25,9 +20,9 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
             // Return Response
             return response;
-        })
+        });
     };
 });

--- a/view/frontend/web/js/action/customer/view/set-subscription-interval.js
+++ b/view/frontend/web/js/action/customer/view/set-subscription-interval.js
@@ -26,8 +26,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
-
+        ).done(function (response) {
             // Return Response
             return response;
         })

--- a/view/frontend/web/js/action/customer/view/set-subscription-item-qty.js
+++ b/view/frontend/web/js/action/customer/view/set-subscription-item-qty.js
@@ -25,7 +25,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/view/set-subscription-status.js
+++ b/view/frontend/web/js/action/customer/view/set-subscription-status.js
@@ -26,7 +26,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
 
             // Return Response
             return response;

--- a/view/frontend/web/js/action/customer/view/skip-subscription-order.js
+++ b/view/frontend/web/js/action/customer/view/skip-subscription-order.js
@@ -25,7 +25,7 @@ define([
             url,
             {},
             false
-        ).success(function (response) {
+        ).done(function (response) {
             // Return Response
             return response;
         })

--- a/view/frontend/web/js/action/set-item-interval.js
+++ b/view/frontend/web/js/action/set-item-interval.js
@@ -31,7 +31,7 @@ define([
             url,
             JSON.stringify(urlParams),
             false
-        ).success(
+        ).done(
             function (response) {
                 customerData.reload(['cart'], false);
                 // Return Response

--- a/view/frontend/web/js/view/customer/addresses/address-modal.js
+++ b/view/frontend/web/js/view/customer/addresses/address-modal.js
@@ -126,7 +126,7 @@ define([
             $('body').trigger('processStart');
 
             postAddressForm('.ps-new-address-modal #form-validate', subscriptionId, addressId)
-                .success(function (response) {
+                .done(function (response) {
                     var address = that.removeUnusedValues(response);
                     addressBuilder.shippingAddress(Object.values(address));
                     // Add address to the default addresses
@@ -140,7 +140,7 @@ define([
                         ]
                     });
                 })
-                .error(function () {
+                .fail(function () {
                     customerData.set('messages', {
                         messages: [
                             {

--- a/view/frontend/web/js/view/customer/addresses/existing-address.js
+++ b/view/frontend/web/js/view/customer/addresses/existing-address.js
@@ -57,7 +57,7 @@ define([
                 var address = Object.values(JSON.parse(response.billing_address));
                 addressBuilder.billingAddress(address);
 
-            }).error(function () {
+            }).fail(function () {
 
                 $('body').trigger('processStop');
                 that.message($t('Unable to update billing address, please try again.'));
@@ -84,7 +84,7 @@ define([
                 var address  = Object.values(response);
                 addressBuilder.shippingAddress(address);
 
-            }).error(function () {
+            }).fail(function () {
 
                 $('body').trigger('processStop');
                 that.message($t('Unable to update shipping address, please try again.'));

--- a/view/frontend/web/js/view/customer/addresses/new-address.js
+++ b/view/frontend/web/js/view/customer/addresses/new-address.js
@@ -81,7 +81,7 @@ define([
                     var address = Object.values(JSON.parse(response.billing_address));
                     addressBuilder.billingAddress(address);
 
-                }).error(function () {
+                }).fail(function () {
                     success = false;
                 })
             }
@@ -94,7 +94,7 @@ define([
                     var address  = Object.values(JSON.parse(response.shipping_address));
                     addressBuilder.shippingAddress(address);
 
-                }).error(function () {
+                }).fail(function () {
                     success = false;
                 })
             }

--- a/view/frontend/web/js/view/customer/list/disabled-subscription.js
+++ b/view/frontend/web/js/view/customer/list/disabled-subscription.js
@@ -65,7 +65,7 @@ define([
             setSubscriptionStatus(
                 this.subscription().subscriptionId,
                 1
-            ).error(function () {
+            ).fail(function () {
                 $("body").trigger('processStop');
                 customerData.set('messages', {
                     messages: [{
@@ -73,7 +73,7 @@ define([
                         type: 'error'
                     }]
                 });
-            }).success(function (subscription) {
+            }).done(function (subscription) {
                 that.handleReActivationSubsriptionListChanges(subscription);
                 $("body").trigger('processStop');
                 customerData.set('messages', {

--- a/view/frontend/web/js/view/customer/list/subscription/product-controls.js
+++ b/view/frontend/web/js/view/customer/list/subscription/product-controls.js
@@ -63,14 +63,14 @@ define([
             setSubscriptionItemQty(
                 this.subscription().item.id,
                 this.qty()
-            ).success(function () {
+            ).done(function () {
                 customerData.set('messages', {
                     messages: [{
                         text: 'Your subscription quantity has been updated.',
                         type: 'success'
                     }]
                 });
-            }).error(function () {
+            }).fail(function () {
                 customerData.set('messages', {
                     messages: [{
                         text: 'Unable to update qty, please try again.',
@@ -88,7 +88,7 @@ define([
             setSubscriptionInterval(
                 this.subscription().subscriptionId,
                 newInterval
-            ).success(function (response) {
+            ).done(function (response) {
                 var nextReleaseDate = dateFormatter(response['next_release_date']);
                 that.subscription().nextReleaseDate(nextReleaseDate);
                 customerData.set('messages', {
@@ -97,7 +97,7 @@ define([
                         type: 'success'
                     }]
                 });
-            }).error(function () {
+            }).fail(function () {
                 customerData.set('messages', {
                     messages: [{
                         text: 'Unable to update your subscription frequency. Please try again.',

--- a/view/frontend/web/js/view/customer/list/subscription/product.js
+++ b/view/frontend/web/js/view/customer/list/subscription/product.js
@@ -41,6 +41,16 @@ define([
                 subscription: ko.observable(this.subscription())
             });
             layout([productControlsComponent]);
+        },
+
+        getSubscriptionOptions: function() {
+            var bundleOptions = this.subscription().product.bundle_options;
+            return Object.keys(bundleOptions).map(function(option) {
+                return {
+                    label: option,
+                    items: bundleOptions[option]
+                };
+            });
         }
     });
 });

--- a/view/frontend/web/js/view/customer/payment/add-braintree-card.js
+++ b/view/frontend/web/js/view/customer/payment/add-braintree-card.js
@@ -105,7 +105,7 @@ define([
                 onPaymentMethodReceived: function (response) {
                     updatePayment(response.nonce, that.subscriptionId).success(function () {
                         location.reload();
-                    }).error(function () {
+                    }).fail(function () {
                         that.message($t('Sorry, but something went wrong when taking the payment.'))
                     });
                 }
@@ -125,7 +125,7 @@ define([
             loadClientToken().done(function(response) {
                 that.clientToken = response.token;
                 that.setup();
-            }).error(function () {
+            }).fail(function () {
                 that.message($t('Sorry, but something went wrong when connecting to Braintree.'))
             });
         },

--- a/view/frontend/web/js/view/customer/payment/add-braintree-paypal.js
+++ b/view/frontend/web/js/view/customer/payment/add-braintree-paypal.js
@@ -82,7 +82,7 @@ define([
                 onPaymentMethodReceived: function (response) {
                     updatePayment(response.nonce, that.subscriptionId).success(function () {
                         location.reload();
-                    }).error(function () {
+                    }).fail(function () {
                         that.message($t('Sorry, but something went wrong when taking the payment.'))
                     });
                 },
@@ -131,7 +131,7 @@ define([
             loadClientToken().done(function(response) {
                 that.clientToken = response.token;
                 that.setup();
-            }).error(function () {
+            }).fail(function () {
                 that.message($t('Sorry, but something went wrong when connecting to Braintree.'))
             });
         },

--- a/view/frontend/web/js/view/customer/payment/edit-payment-modal.js
+++ b/view/frontend/web/js/view/customer/payment/edit-payment-modal.js
@@ -93,7 +93,7 @@ define([
             var subscriptionId = this.subscription().subscriptionId;
             $('body').trigger('processStart');
             setPaymentMethod(subscriptionId, paymentMethodHash)
-                .success(function (response) {
+                .done(function (response) {
                     // Add address to the default addresses
                     customerData.set('messages', {
                         messages: [
@@ -104,7 +104,7 @@ define([
                         ]
                     });
                 })
-                .error(function () {
+                .fail(function () {
                     customerData.set('messages', {
                         messages: [
                             {

--- a/view/frontend/web/js/view/customer/view/delivery.js
+++ b/view/frontend/web/js/view/customer/view/delivery.js
@@ -57,7 +57,7 @@ define([
                 // Add error messaging
                 that.message($t('Unable to update frequency, please try again.'));
                 that.messageClass('message error');
-            }).success(function () {
+            }).done(function () {
 
                 // Stop loader
                 $('body').trigger('processStop');

--- a/view/frontend/web/js/view/customer/view/status.js
+++ b/view/frontend/web/js/view/customer/view/status.js
@@ -57,7 +57,7 @@ define([
                 // Add error messaging
                 that.message($t('Unable to update the status, please try again.'));
                 that.messageClass('message error');
-            }).success(function () {
+            }).done(function () {
 
                 // Stop loader
                 $('body').trigger('processStop');

--- a/view/frontend/web/template/customer/list/component/product.html
+++ b/view/frontend/web/template/customer/list/component/product.html
@@ -9,8 +9,19 @@
             </p>
             <p data-bind="html: subscription().product.price"></p>
             <!-- ko if: frequencyLabel -->
-                <span data-bind="i18n: 'Order Frequency: '"></span><span data-bind="html: frequencyLabel"></span>
+            <span data-bind="i18n: 'Order Frequency: '"></span><span data-bind="html: frequencyLabel"></span>
             <!-- /ko -->
+            <div class="product-info__options">
+                <!-- ko foreach: { data: getSubscriptionOptions(), as: 'option' } -->
+                <div class="product-info__options-list" data-bind="if: option.items.length > 0">
+                    <p class="product-info__options-title" data-bind="text: option.label"></p>
+                    <!-- ko foreach: { data: option.items, as: 'item' } -->
+                    <p data-bind="text: parseFloat(item.quantity).toString().replace(/\.0+$/, '') + ' x ' + item.name + ' ' + item.selection_price"></p>
+                    <p data-bind="text: 'Sku: ' + item.sku"></p>
+                    <!-- /ko -->
+                </div>
+                <!-- /ko -->
+            </div>
         </div>
     </div>
     <!-- ko foreach: { data: elems, as: 'element' } -->


### PR DESCRIPTION
### Description

Implement logic to allow subscription on specific types of bundle products. Only the following bundles are eligible for subscriptions:

- Fixed price & fixed sku
- Fixed price & dynamic sku

The following bundle configurations are not eligible for subscriptions:

- Any dynamic price configured bundle
- Any bundle with more than 1 product per bundle option
- Any bundle with a 'User Defined' option

PR also contains following updates:

- Updates to emails to include bundle option data
- Update to available payment methods to only return Braintree methods
- Updates to account area to display bundle options for subscription items