### PR TITLE
Remove deprecated zend validator

### DIFF
--- a/Setup/Patch/Data/AddProductSubscriptionAttributes.php
+++ b/Setup/Patch/Data/AddProductSubscriptionAttributes.php
@@ -11,9 +11,9 @@ use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Validator\ValidateException;
 use PayPal\Subscription\Model\Config\Source\Subscription\FrequencyProfile;
 use PayPal\Subscription\Model\Config\Source\Subscription\PriceType;
-use Zend_Validate_Exception;
 
 /**
  * Class AddProductSubscriptionAttributes
@@ -72,7 +72,7 @@ class AddProductSubscriptionAttributes implements DataPatchInterface
 
     /**
      * @throws LocalizedException
-     * @throws Zend_Validate_Exception
+     * @throws ValidateException
      */
     public function apply()
     {

--- a/Setup/Patch/Data/UpdateProductSubscriptionAttributes.php
+++ b/Setup/Patch/Data/UpdateProductSubscriptionAttributes.php
@@ -11,7 +11,7 @@ use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
-use Zend_Validate_Exception;
+use Magento\Framework\Validator\ValidateException;
 
 /**
  * Class UpdateProductSubscriptionAttributes
@@ -73,7 +73,7 @@ class UpdateProductSubscriptionAttributes implements DataPatchInterface
 
     /**
      * @throws LocalizedException
-     * @throws Zend_Validate_Exception
+     * @throws ValidateException
      */
     public function apply()
     {


### PR DESCRIPTION
### Description

Fix outdated zend validator class. Usage of this class was causing codesniffer to fail.

![image](https://github.com/genecommerce/paypal-subscription-module/assets/137045660/89cca046-7b50-4b60-97f6-8bc31201c859)
