### PR TITLE
3.1.0 - Subscription release order totals fix

### DIFF
--- a/Model/CreateSubscriptionQuote.php
+++ b/Model/CreateSubscriptionQuote.php
@@ -186,6 +186,7 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
         $quote->setStore($store);
         $quote->setCustomer($customer);
         $quote->setIsActive(false);
+        $quote->setData('is_subscription_release', true);
         try {
             $this->addProductsToQuote(
                 $quote,

--- a/Model/SubscriptionItemManagement.php
+++ b/Model/SubscriptionItemManagement.php
@@ -44,7 +44,7 @@ class SubscriptionItemManagement implements SubscriptionItemManagementInterface
         $subscriptionItem = $this->subscriptionItem->create();
         $subscriptionItem->setSubscriptionId((int) $subscription->getId());
         $subscriptionItem->setSku($item->getSku());
-        $subscriptionItem->setPrice((float) $item->getPrice());
+        $subscriptionItem->setPrice((float) $item->getPriceInclTax());
         $subscriptionItem->setQty((int) $item->getQtyOrdered());
         $subscriptionItem->setProductId((int) $item->getProductId());
         $this->subscriptionItemRepository->save($subscriptionItem);

--- a/Observer/ReleaseProductAdd.php
+++ b/Observer/ReleaseProductAdd.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace PayPal\Subscription\Observer;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote\Item;
+
+class ReleaseProductAdd implements ObserverInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Item $item */
+        $item = $observer->getEvent()->getData('quote_item');
+
+        if (!$item->getQuote() instanceof CartInterface ||
+            (bool) $item->getQuote()->getData('is_subscription_release') !== true
+        ) {
+            return;
+        }
+
+        $product = $item->getProduct();
+        if (!$product instanceof ProductInterface) {
+            throw new NotFoundException(__("Could not find product for quote item ID %1", $item->getItemId()));
+        }
+
+        // Subscription price already set to product, use as custom price on quote item.
+        $subscriptionPrice = (float) $product->getPrice();
+        $item->setCustomPrice($subscriptionPrice);
+        $item->setOriginalCustomPrice($subscriptionPrice);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Enable products to be purchased as a subscription.",
     "type": "magento2-module",
     "license": "proprietary",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "authors": [
         {
             "email": "hello@gene.co.uk",

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -34,4 +34,7 @@
     <event name="catalog_product_save_before">
         <observer name="paypal_subscription_disable_bundle_attributes" instance="PayPal\Subscription\Observer\DisableBundleAttributes" />
     </event>
+    <event name="sales_quote_add_item">
+        <observer name="paypal_subscription_release_product_add" instance="PayPal\Subscription\Observer\ReleaseProductAdd" />
+    </event>
 </config>


### PR DESCRIPTION
### Description

Ensure order totals are correct for subscription releases. Price incl tax must be saved to subscription item and subscription item price must be applied as custom price to release quote items.

PR: https://github.com/genecommerce/paypal-subscription-module/pull/6