### PR TITLE
Automatic price update feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2024-03-05
+### Added
+- Automatic price update feature:
+  - Add config setting to enable automatic price updates on subscriptions
+  - When enabled, subscription releases use latest product price information.
+  - When disabled, subscription releases use the price associated to original subscription order.
+  - If auto price update enabled and price has changed since last release, a price update email is sent to customer.
+
 ## [3.1.0] - 2024-03-05
 ### Added
 - Fixes for subscription release order totals

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -177,4 +177,16 @@ class Configuration implements ConfigurationInterface
             $scopeCode
         );
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAutoUpdatePrice(string $scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null): bool
+    {
+        return (bool) $this->scopeConfig->getValue(
+            self::AUTO_UPDATE_PRICE,
+            $scopeType,
+            $scopeCode
+        );
+    }
 }

--- a/Model/ConfigurationInterface.php
+++ b/Model/ConfigurationInterface.php
@@ -16,6 +16,7 @@ interface ConfigurationInterface
     public const ERROR_LOGGING_EMAIL_ENABLED = 'paypal_subscriptions/email_configuration/error_logging_emails_enabled';
     public const ERROR_LOGGING_EMAIL_RECIPIENTS = 'paypal_subscriptions/email_configuration/error_logging_emails_recipients';
     public const RELEASE_REMINDER_TIMING = 'paypal_subscriptions/email_configuration/release_reminder_timing';
+    public const AUTO_UPDATE_PRICE = 'paypal/subscriptions/auto_update_price';
 
     /**
      * Get Configuration value for Is Active
@@ -112,4 +113,13 @@ interface ConfigurationInterface
         string $scopeType = ScopeInterface::SCOPE_STORE,
         $scopeCode = null
     ): int;
+
+    /**
+     * Get Configuration value for auto update product prices.
+     *
+     * @param string $scopeType
+     * @param null $scopeCode
+     * @return bool
+     */
+    public function getAutoUpdatePrice(string $scopeType = ScopeInterface::SCOPE_STORE, $scopeCode = null): bool;
 }

--- a/Model/CreateSubscriptionOrder.php
+++ b/Model/CreateSubscriptionOrder.php
@@ -13,6 +13,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\InvoiceOrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Store\Model\ScopeInterface;
 use PayPal\Subscription\Api\Data\SubscriptionInterface;
 
 class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
@@ -38,11 +39,13 @@ class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
      * @param InvoiceOrderInterface $invoiceOrder
      * @param CartManagementInterface $quoteManagement
      * @param OrderRepositoryInterface $orderRepository
+     * @param ConfigurationInterface $config
      */
     public function __construct(
         InvoiceOrderInterface $invoiceOrder,
         CartManagementInterface $quoteManagement,
-        OrderRepositoryInterface $orderRepository
+        OrderRepositoryInterface $orderRepository,
+        private readonly ConfigurationInterface $config
     ) {
         $this->invoiceOrder = $invoiceOrder;
         $this->quoteManagement = $quoteManagement;
@@ -104,6 +107,11 @@ class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
                     $subscription->getFailedPayments()+1
                 );
             }
+        }
+        if ($subscription instanceof SubscriptionInterface &&
+            $this->config->getAutoUpdatePrice(ScopeInterface::SCOPE_STORE, $order->getStoreId()) === true
+        ) {
+            $subscription->setOrderId((int) $order->getId());
         }
         return $order;
     }

--- a/Model/CreateSubscriptionOrder.php
+++ b/Model/CreateSubscriptionOrder.php
@@ -13,7 +13,6 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\InvoiceOrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
-use Magento\Store\Model\ScopeInterface;
 use PayPal\Subscription\Api\Data\SubscriptionInterface;
 
 class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
@@ -39,13 +38,11 @@ class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
      * @param InvoiceOrderInterface $invoiceOrder
      * @param CartManagementInterface $quoteManagement
      * @param OrderRepositoryInterface $orderRepository
-     * @param ConfigurationInterface $config
      */
     public function __construct(
         InvoiceOrderInterface $invoiceOrder,
         CartManagementInterface $quoteManagement,
-        OrderRepositoryInterface $orderRepository,
-        private readonly ConfigurationInterface $config
+        OrderRepositoryInterface $orderRepository
     ) {
         $this->invoiceOrder = $invoiceOrder;
         $this->quoteManagement = $quoteManagement;
@@ -107,11 +104,6 @@ class CreateSubscriptionOrder implements CreateSubscriptionOrderInterface
                     $subscription->getFailedPayments()+1
                 );
             }
-        }
-        if ($subscription instanceof SubscriptionInterface &&
-            $this->config->getAutoUpdatePrice(ScopeInterface::SCOPE_STORE, $order->getStoreId()) === true
-        ) {
-            $subscription->setOrderId((int) $order->getId());
         }
         return $order;
     }

--- a/Model/CreateSubscriptionQuote.php
+++ b/Model/CreateSubscriptionQuote.php
@@ -274,7 +274,7 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
                 if ($product !== null &&
                     $productQuoteData !== null) {
                     if ($autoUpdate === true) {
-                        $subscriptionPrice = $this->getSubscriptionPrice($product);
+                        $subscriptionPrice = $this->getLatestSubscriptionPrice($product);
                         if ($subscriptionPrice !== $productQuoteData[ProductInterface::PRICE]) {
                             $subscriptionItem->setPrice($subscriptionPrice);
                             $this->subscriptionItemRepository->save($subscriptionItem);
@@ -419,7 +419,7 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
      * @return float
      * @throws LocalizedException
      */
-    private function getSubscriptionPrice(ProductInterface $product): float
+    private function getLatestSubscriptionPrice(ProductInterface $product): float
     {
         $priceType = $product->getData(SubscriptionHelper::SUB_PRICE_TYPE) !== null
             ? (int) $product->getData(SubscriptionHelper::SUB_PRICE_TYPE)

--- a/Model/CreateSubscriptionQuote.php
+++ b/Model/CreateSubscriptionQuote.php
@@ -278,8 +278,8 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
                         if ($subscriptionPrice !== $productQuoteData[ProductInterface::PRICE]) {
                             $subscriptionItem->setPrice($subscriptionPrice);
                             $this->subscriptionItemRepository->save($subscriptionItem);
+                            $subscription->setData('price_changed', true);
                         }
-                        // TODO: TRIGGER PRICE CHANGE EMAIL
                     } else {
                         // Use existing subscription price.
                         $subscriptionPrice = $productQuoteData[ProductInterface::PRICE];

--- a/Model/CreateSubscriptionQuote.php
+++ b/Model/CreateSubscriptionQuote.php
@@ -24,10 +24,13 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
+use PayPal\Subscription\Api\SubscriptionItemRepositoryInterface;
 use PayPal\Subscription\Api\Data\SubscriptionInterface;
 use PayPal\Subscription\Api\Data\SubscriptionItemInterface;
+use PayPal\Subscription\Helper\Data as SubscriptionHelper;
 use PayPal\Subscription\Model\Payment\PaymentMethodPoolInterface;
 use PayPal\Subscription\Model\ResourceModel\SubscriptionItem\Collection as SubscriptionItemCollection;
 use PayPal\Subscription\Model\ResourceModel\SubscriptionItem\CollectionFactory as SubscriptionItemCollectionFactory;
@@ -122,6 +125,8 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
      * @param ProductRepositoryInterface $productRepository
      * @param Configurable $configurableType
      * @param DataObjectFactory $dataObjectFactory
+     * @param SubscriptionHelper $helper
+     * @param SubscriptionItemRepositoryInterface $subscriptionItemRepository
      */
     public function __construct(
         CustomerRepositoryInterface $customerRepository,
@@ -137,7 +142,9 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
         OrderRepositoryInterface $orderRepository,
         ProductRepositoryInterface $productRepository,
         Configurable $configurableType,
-        DataObjectFactory $dataObjectFactory
+        DataObjectFactory $dataObjectFactory,
+        private readonly SubscriptionHelper $helper,
+        private readonly SubscriptionItemRepositoryInterface $subscriptionItemRepository
     ) {
         $this->customerRepository = $customerRepository;
         $this->paymentMethodPool = $paymentMethodPool;
@@ -237,6 +244,7 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
     ): void {
         $subscriptionItemProductData = [];
         $productIds = [];
+        $autoUpdate = $this->configuration->getAutoUpdatePrice(ScopeInterface::SCOPE_STORE, $quote->getStoreId());
         foreach ($subscriptionItems as $subscriptionItem) {
             $productId = $subscriptionItem->getProductId();
             if (!in_array($productId, $productIds)) {
@@ -265,9 +273,18 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
                 $productQuoteData = $subscriptionItemProductData[$subscriptionItem->getId()] ?? null;
                 if ($product !== null &&
                     $productQuoteData !== null) {
-                    $product->setPrice(
-                        $productQuoteData[ProductInterface::PRICE]
-                    );
+                    if ($autoUpdate === true) {
+                        $subscriptionPrice = $this->getSubscriptionPrice($product);
+                        if ($subscriptionPrice !== $productQuoteData[ProductInterface::PRICE]) {
+                            $subscriptionItem->setPrice($subscriptionPrice);
+                            $this->subscriptionItemRepository->save($subscriptionItem);
+                        }
+                        // TODO: TRIGGER PRICE CHANGE EMAIL
+                    } else {
+                        // Use existing subscription price.
+                        $subscriptionPrice = $productQuoteData[ProductInterface::PRICE];
+                    }
+                    $product->setPrice($subscriptionPrice);
                     if ($productQuoteData[ProductInterface::SKU] !== $product->getSku() &&
                         $product->getTypeId() === Configurable::TYPE_CODE) {
                         $this->addConfigProductToQuote(
@@ -395,5 +412,36 @@ class CreateSubscriptionQuote implements CreateSubscriptionQuoteInterface
             $quote,
             $paymentData
         );
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @return float
+     * @throws LocalizedException
+     */
+    private function getSubscriptionPrice(ProductInterface $product): float
+    {
+        $priceType = $product->getData(SubscriptionHelper::SUB_PRICE_TYPE) !== null
+            ? (int) $product->getData(SubscriptionHelper::SUB_PRICE_TYPE)
+            : null;
+        $priceValue = $product->getData(SubscriptionHelper::SUB_PRICE_VALUE) !== null
+            ? (float) $product->getData(SubscriptionHelper::SUB_PRICE_VALUE)
+            : null;
+
+        if ($priceValue === null) {
+            throw new LocalizedException(
+                __("Product %1 has no subscription price value defined", $product->getId())
+            );
+        }
+
+        if ($priceType === SubscriptionHelper::FIXED_PRICE) {
+            return $priceValue;
+        } elseif ($priceType === SubscriptionHelper::DISCOUNT_PRICE) {
+            $discountedPrice = $this->helper->getDiscountedPrice(
+                $priceValue,
+                (float) $product->getPrice()
+            );
+            return $discountedPrice;
+        }
     }
 }

--- a/Model/Email/Release.php
+++ b/Model/Email/Release.php
@@ -127,6 +127,24 @@ class Release extends Email
 
     /**
      * @param CustomerInterface $customer
+     * @param int $originalOrderId
+     * @param int $newOrderId
+     * @return array
+     */
+    public function priceChanged(CustomerInterface $customer, int $originalOrderId, int $newOrderId): array
+    {
+        $data = [
+            'customer_name' => sprintf(
+                '%1$s %2$s',
+                $customer->getFirstname(),
+                $customer->getLastname()
+            ),
+
+        ];
+    }
+
+    /**
+     * @param CustomerInterface $customer
      * @param SubscriptionInterface $subscription
      * @param string $reason
      * @return array

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Enable products to be purchased as a subscription.",
     "type": "magento2-module",
     "license": "proprietary",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "authors": [
         {
             "email": "hello@gene.co.uk",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -98,6 +98,11 @@
                     <comment>Email template chosen based on theme fallback when "Default" option is selected.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Email\Template</source_model>
                 </field>
+                <field id="price_changed" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Price Changed Email Template</label>
+                    <comment>Email template chosen based on theme fallback when "Default" option is selected.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Email\Template</source_model>
+                </field>
                 <field id="release_reminder_timing" translate="label comment" type="text" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Release Reminder Email Timing</label>
                     <comment>In days before release. If set to 0 the release reminder will be sent as the release is created. Any other number will be taken as days before the next release date.</comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -54,6 +54,12 @@
                         <field id="active">1</field>
                     </depends>
                 </field>
+                <field id="auto_update_price" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Automatically Update Product Prices</label>
+                    <comment>If enabled, subscription orders will always use the current price information set to the product. If disabled, subscription orders will always use the original subscription price value</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>paypal/subscriptions/auto_update_price</config_path>
+                </field>
             </group>
             <group id="email_configuration" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Email Configuration</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,7 +18,6 @@
             </configuration>
             <email_configuration>
                 <release_reminder_timing>0</release_reminder_timing>
-                <release_reminder_timing>0</release_reminder_timing>
             </email_configuration>
         </paypal_subscriptions>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,7 @@
                 <message_broker>1</message_broker>
                 <cron_schedule>0 0 * * *</cron_schedule>
                 <allowed_payment_methods>braintree,braintree_paypal,braintree_paypal_vault,braintree_cc_vault</allowed_payment_methods>
+                <auto_update_price>0</auto_update_price>
             </configuration>
             <email_configuration>
                 <release_reminder_timing>0</release_reminder_timing>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,14 +11,16 @@
             <configuration>
                 <failed_payments>5</failed_payments>
                 <stock_failures_allowed>5</stock_failures_allowed>
-                <message_broker>1</message_broker>
-                <cron_schedule>0 0 * * *</cron_schedule>
                 <allowed_payment_methods>braintree,braintree_paypal,braintree_paypal_vault,braintree_cc_vault</allowed_payment_methods>
                 <auto_update_price>0</auto_update_price>
             </configuration>
             <email_configuration>
                 <release_reminder_timing>0</release_reminder_timing>
             </email_configuration>
+            <developer_configuration>
+                <message_broker>1</message_broker>
+                <cron_schedule>0 0 * * *</cron_schedule>
+            </developer_configuration>
         </paypal_subscriptions>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,6 +18,7 @@
             </configuration>
             <email_configuration>
                 <release_reminder_timing>0</release_reminder_timing>
+                <release_reminder_timing>0</release_reminder_timing>
             </email_configuration>
         </paypal_subscriptions>
     </default>

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -54,4 +54,10 @@
               type="html"
               module="PayPal_Subscription"
               area="frontend"/>
+    <template id="paypal_subscriptions_email_configuration_price_changed"
+              label="Subscription Price Changed Email"
+              file="subscription_price_changed.html"
+              type="html"
+              module="PayPal_Subscription"
+              area="frontend"/>
 </config>

--- a/view/frontend/email/subscription_price_changed.html
+++ b/view/frontend/email/subscription_price_changed.html
@@ -1,0 +1,27 @@
+<!--@subject {{trans "The Price Has Changed For Your %store_name Subscription" store_name=$store.frontend_name}} @-->
+<!--@vars {
+"var customer_name":"Customer Name",
+"layout handle=\"subscription_items\" subscription=$subscription area=\"frontend\"":"Subscription Items Grid",
+"var subscription":"Subscription",
+"var store":"Store",
+"var formatted_next_release":"Formatted Next Release Date",
+"var original_order_total":"Original Order Total",
+"var new_order_total":"New Order Total"
+} @-->
+{{template config_path="design/email/header_template"}}
+
+<p>{{trans "Hi %customer_name" customer_name=$customer_name}},</p>
+
+<p>{{trans "The price for your %formatted_next_release subscription order has changed." formatted_next_release=$formatted_next_release}}</p>
+
+<p><strong>{{trans "Products:"}}</strong></p>
+{{layout handle="subscription_items" items=$items area="frontend"}}
+<br/>
+
+<p><strong>{{trans "Previous order total: "}}</strong>{{var original_order_total}}</p>
+<p><strong>{{trans "New order total: "}}</strong>{{var new_order_total}}</p>
+
+<br/>
+<p>{{trans "You can easily manage your subscriptions by going to My Account > Subscriptions If you have any questions, please contact us"}}.</p>
+
+{{template config_path="design/email/footer_template"}}


### PR DESCRIPTION
### Description

- Add config setting to enable automatic price updates on subscriptions
- When enabled, subscription releases use latest product price information.
- When disabled, subscription releases use the price associated to original subscription order.
- If auto price update enabled and price has changed since last release, a price update email is sent to customer.

### Screenshots

**Email**
![image](https://github.com/genecommerce/paypal-subscription-module/assets/137045660/791f428b-43f2-4d29-88f1-a2202f3afb4a)
