### PR TITLE
Fix incorrect public hash for existing vault token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Check and disable "Save for later" checkbox on payment step in checkout if cart contains any subscription items 
 - Add message to tooltip for user
+- Create plugin to prevent following integrity constraint violation during order placement when vaulted token has been created via customer account page
 
 ## [3.3.0] - 2024-04-16
 ### Added

--- a/Plugin/Braintree/ExistingPublicHash.php
+++ b/Plugin/Braintree/ExistingPublicHash.php
@@ -23,6 +23,18 @@ class ExistingPublicHash
     }
 
     /**
+     * Error occurs when the vaulted token has been saved with token details including customer ID:
+     * @see \PayPal\Braintree\Model\Adapter\PaymentMethod\BraintreePaymentTokenAdapter::getTokenDetails
+     *
+     * During order placement, Braintree responds with gateway token information which is then persisted to vault token.
+     * During the order process, the public hash is then generated dynamically and stored against this token.
+     *
+     * When the public hash for this token is generated dynamically, the customer ID is NOT included in the token detail
+     * @see \PayPal\Braintree\Gateway\Response\VaultDetailsHandler::getVaultPaymentToken
+     *
+     * This results in a different public hash value being generated for an existing gateway token.
+     * Fix here ensures we use existing public hash for stored token during save.
+     *
      * @param Subject $subject
      * @param PaymentTokenInterface $token
      * @param OrderPaymentInterface $payment

--- a/Plugin/Braintree/ExistingPublicHash.php
+++ b/Plugin/Braintree/ExistingPublicHash.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace PayPal\Subscription\Plugin\Braintree;
+
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use Magento\Vault\Api\PaymentTokenManagementInterface as Subject;
+use Psr\Log\LoggerInterface;
+
+class ExistingPublicHash
+{
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @param Subject $subject
+     * @param PaymentTokenInterface $token
+     * @param OrderPaymentInterface $payment
+     * @return array
+     */
+    public function beforeSaveTokenWithPaymentLink(
+        Subject $subject,
+        PaymentTokenInterface $token,
+        OrderPaymentInterface $payment
+    ): array {
+        try {
+            $existingToken = $subject->getByGatewayToken(
+                $token->getGatewayToken(),
+                $token->getPaymentMethodCode(),
+                $token->getCustomerId()
+            );
+            if ($existingToken instanceof PaymentTokenInterface &&
+                $existingToken->getPublicHash() !== $token->getPublicHash() &&
+                $this->tokensAreBraintree($token, $existingToken) === true
+            ) {
+                $token->setPublicHash($existingToken->getPublicHash());
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error("An error occurred whilst setting existing public hash to current token", [
+                'exception_message' => $exception->getMessage(),
+            ]);
+        }
+        return [$token, $payment];
+    }
+
+    /**
+     * @param PaymentTokenInterface $token
+     * @param PaymentTokenInterface $existingToken
+     * @return bool
+     */
+    private function tokensAreBraintree(PaymentTokenInterface $token, PaymentTokenInterface $existingToken): bool
+    {
+        return $token->getPaymentMethodCode() === 'braintree' && $existingToken->getPaymentMethodCode() === 'braintree';
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -199,4 +199,7 @@
         <plugin name="DisableInstantButton"
                 type="PayPal\Subscription\Plugin\DisableInstantButton"/>
     </type>
+    <type name="Magento\Vault\Api\PaymentTokenManagementInterface">
+        <plugin name="paypal_existing_public_hash" type="PayPal\Subscription\Plugin\Braintree\ExistingPublicHash"/>
+    </type>
 </config>


### PR DESCRIPTION
### Description

Create plugin to prevent following integrity constraint violation during order placement when vaulted token has been created via customer account page
```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'braintree-118379-nbyfd777' for key 'VAULT_PAYMENT_TOKEN_PAYMENT_METHOD_CODE_CSTR_ID_GATEWAY_TOKEN', query was: INSERT INTO `vault_payment_token` (`customer_id`, `public_hash`, `payment_method_code`, `type`, `expires_at`, `gateway_token`, `details`, `is_active`, `is_visible`, `website_id`) VALUES (?, ?, ?, ?, '2026-01-01 00:00:00', ?, ?, ?, ?, ?)
```

This error occurs when the vaulted token has been saved with token details including customer ID:
- https://github.com/genecommerce/ext-braintree/blob/2.4.7-release/Braintree/Model/Adapter/PaymentMethod/BraintreePaymentTokenAdapter.php#L122

During order placement, Braintree responds with gateway token information which is then persisted to a vault token and set to order payment object. During the order process, the public hash is then dynamically generated and stored against this token. 

When the public hash for this token is generated dynamically, the customer ID is not included in the token details information - resulting in a different public hash value being generated for an existing gateway token
- https://github.com/genecommerce/ext-braintree/blob/2.4.7-release/Braintree/Gateway/Response/VaultDetailsHandler.php#L62-L66

This then results in integrity error during `saveTokenWithPaymentLink` function call in `\Magento\Vault\Observer\AfterPaymentSaveObserver::execute`.

### Fix

Fix is to ensure we load the payment token via gateway token. If token exists, use the public hash value we already have saved into the database.