### PR TITLE
Amended logic for handling if card should be saved

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted-fields-mixin.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted-fields-mixin.js
@@ -26,15 +26,6 @@ define([], function () {
              */
             cartContainsSubscriptions: function () {
                 return quoteItemData.some(item => item.is_subscription === "1");
-            },
-
-            /**
-             * @returns {Bool}
-             */
-            savePaymentCheckbox: function () {
-                var isActivePaymentTokenEnabler = this.vaultEnabler.isActivePaymentTokenEnabler();
-                // Set checkbox as checked if cart contains any subscriptions.
-                return this.cartContainsSubscriptions() === true ? true : isActivePaymentTokenEnabler;
             }
         });
     };

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -117,7 +117,7 @@
                     <input type="checkbox"
                            name="vault[is_enabled]"
                            class="checkbox"
-                           data-bind="attr: {'id': getCode() + '_enable_vault'}, checked: savePaymentCheckbox(), disable: cartContainsSubscriptions()">
+                           data-bind="attr: {'id': getCode() + '_enable_vault'}, checked: vaultEnabler.isActivePaymentTokenEnabler || cartContainsSubscriptions(), disable: cartContainsSubscriptions()">
                     <label class="label" data-bind="attr: {'for': getCode() + '_enable_vault'}">
                         <span><!-- ko i18n: 'Save for later use.'--><!-- /ko --></span>
                     </label>


### PR DESCRIPTION
## What
When the checkbox for vaulting a card was being clicked it was always activating the JS that returned the default value of true and therefore every time the form was submitted the card would be vaulted even if the checkbox was not checked.

## Fix
Removed the logic, and instead add condition onto the checkbox to check for subscription 

Examples of orders with/without the box ticked in this video [here](https://www.loom.com/share/2ed50657effa4a83aca5d7e677f369ed)