### PR TITLE
Fix hosted fields vault checkbox state handling

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/hosted-fields-mixin.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hosted-fields-mixin.js
@@ -5,7 +5,7 @@ define([], function () {
      * Quote Item Data
      * @type {Window.checkoutConfig.quoteItemData}
      */
-    var quoteItemData = window.checkoutConfig.quoteItemData ?? [];
+    let quoteItemData = window.checkoutConfig.quoteItemData ?? [];
 
     return function (originalHostedFields) {
         return originalHostedFields.extend({
@@ -40,9 +40,9 @@ define([], function () {
             getData: function () {
                 let data = this._super();
 
-                data['additional_data']['is_active_payment_token_enabler'] = this.cartContainsSubscriptions() === true
-                    ? true
-                    : this.isActivePaymentTokenEnabler();
+                if (this.cartContainsSubscriptions() === true) {
+                    data['additional_data']['is_active_payment_token_enabler'] = true;
+                }
 
                 return data;
             }


### PR DESCRIPTION
- Use the base vault enabler flow for non-subscription carts instead of calling isActivePaymentTokenEnabler on the hosted-fields component.
- Keep forcing the vault additional-data flag only when the cart contains subscription items.